### PR TITLE
DDCNL-8939: update hmrc-mongo, add test package, add toggle for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,26 @@ This library is a client to use mongo as storage for feature toggles.
 "uk.gov.hmrc" %% s"mongo-feature-toggles-client-$playVersion" % hmrcMongoFeatureTogglesClientVersion
 ```
 
+You can also add the following in Test which will bring bootstrap-play-test and hmrc-mongo-test
+```sbt
+"uk.gov.hmrc" %% s"mongo-feature-toggles-client-test-$playVersion" % hmrcMongoFeatureTogglesClientVersion
+```
+
 ### Add the mongodb uri if not already present in application.conf and app-config-*
-Note the library is using transaction in mongo which requires mongo to be run as a cluster. 
+Note the library is using transaction in mongo which requires mongo to be run as a cluster.
 If you see the error `com.mongodb.MongoClientException, with message: This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string`
 when running tests, your mongo is not running as a cluster.
 
 ### Add internal auth binding
-The library uses [internal-auth-client](https://github.com/hmrc/internal-auth-client). 
+The library uses [internal-auth-client](https://github.com/hmrc/internal-auth-client).
 You will need to add the following binding to your ```application.conf```, unless your service already uses the ```internal-auth-client```, in which case this binding will already exist.
 ```scala
 play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 ```
+
+### Mongo transactions override
+If the the configuration `mongo-feature-toggles-client.useMongoTransactions = false` is used then the client won't use Mongo transactions. Do not override this in any environment. It is best suited while the service is started via service manager.
 
 ### Create a toggle
 Create a case object extending the FeatureFlagName trait
@@ -57,12 +66,12 @@ play.modules.enabled += "config.HmrcModule"
 ```
 
 ### Add the additional admin routes in admin.routes
-```text 
+```text
 -> /featureFlags mongoFeatureTogglesAdmin.Routes
 ```
 
 ### Add the additional test-only routes in testOnlyDoNotUseInAppConf.routes
-```text 
+```text
 -> /<rootPath> mongoFeatureTogglesTestOnly.Routes
 ```
 

--- a/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/internal/config/AppConfig.scala
+++ b/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/internal/config/AppConfig.scala
@@ -31,4 +31,9 @@ private[mongoFeatureToggles] class AppConfig @Inject() (configuration: Configura
     configuration
       .getOptional[String]("microservice.services.internal-auth.resource-type")
       .getOrElse("ddcn-live-admin-frontend")
+
+  val useMongoTransactions: Boolean =
+    configuration
+      .getOptional[Boolean]("mongo-feature-toggles-client.useMongoTransactions")
+      .getOrElse(true)
 }

--- a/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositoryWithoutTransactionsSpec.scala
+++ b/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositoryWithoutTransactionsSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mongoFeatureToggles.internal.repository
+
+import org.mongodb.scala.bson.BsonDocument
+import play.api.Application
+import play.api.inject.bind
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.mongoFeatureToggles.internal.model.FeatureFlagSerialised
+import uk.gov.hmrc.mongoFeatureToggles.model.{FeatureFlagName, FeatureFlagNamesLibrary}
+import uk.gov.hmrc.mongoFeatureToggles.testUtils.{BaseSpec, TestToggleA, TestToggleB}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class FeatureFlagRepositoryWithoutTransactionsSpec
+    extends BaseSpec
+    with DefaultPlayMongoRepositorySupport[FeatureFlagSerialised] {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    FeatureFlagNamesLibrary.addFlags(List(TestToggleA, TestToggleB))
+  }
+
+  override protected lazy val optSchema: Option[BsonDocument] = Some(BsonDocument("""
+      { bsonType: "object"
+      , required: [ "_id", "name", "isEnabled" ]
+      , properties:
+        { _id       : { bsonType: "objectId" }
+        , name      : { bsonType: "string" }
+        , isEnabled : { bsonType: "bool" }
+        , description : { bsonType: "string" }
+        }
+      }
+    """))
+
+  override implicit lazy val app: Application = localGuiceApplicationBuilder()
+    .configure(
+      Map("mongodb.uri" -> mongoUri, "mongo-feature-toggles-client.useMongoTransactions" -> "false")
+        ++ configValues
+    )
+    .overrides(
+      bind[MongoComponent].toInstance(mongoComponent)
+    )
+    .build()
+
+  override val checkTtlIndex = false
+
+  lazy val repository: FeatureFlagRepository = app.injector.instanceOf[FeatureFlagRepository]
+
+  "setFeatureFlags" must {
+    "set multiple records" in {
+      val expectedFlags: Map[FeatureFlagName, Boolean] =
+        Map(TestToggleA -> false, TestToggleB -> true)
+      val result                                       = (for {
+        _      <- repository.setFeatureFlags(expectedFlags)
+        result <- findAll()
+      } yield result).futureValue
+
+      result.sortBy(_.name) mustBe expectedFlags
+        .map { case (key, value) =>
+          FeatureFlagSerialised(key.name, value, key.description)
+        }
+        .toList
+        .sortBy(_.name)
+    }
+  }
+}

--- a/project/BuildDependencies.scala
+++ b/project/BuildDependencies.scala
@@ -3,19 +3,19 @@ import sbt.*
 
 private object BuildDependencies {
 
-  private val hmrcMongoVersion          = "1.7.0"
-  private val bootstrapVersion          = "8.5.0"
-  private val internalAuthClientVersion = "1.10.0"
+  val hmrcMongoVersion          = "1.9.0"
+  val bootstrapVersion          = "8.5.0"
+  private val internalAuthClientVersion = "2.0.0"
 
   //Intentionally left on an older version
-  private val bootstrapVersion28 = "7.23.0"
+  val bootstrapVersion28 = "7.23.0"
 
   private val collectionCompatVersion   = "2.11.0"
   private val mockitoScalatestVersion   = "1.17.30"
 
-  private val playVersion28 = "play-28"
-  private val playVersion29 = "play-29"
-  private val playVersion30 = "play-30"
+  val playVersion28 = "play-28"
+  val playVersion29 = "play-29"
+  val playVersion30 = "play-30"
 
   val compile28: Seq[ModuleID] = Seq(
     caffeine,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ sys.env.get("PLAY_VERSION") match {
   case _           => addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 }
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.21.0")
 addSbtPlugin("uk.gov.hmrc"   % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"      % "2.0.11")


### PR DESCRIPTION
- update hmrc-mongo dependency to 2.0.0
- add a test package to make it easier by abstracting hmrc-mongo-test package
- add an override to disable transactions