### PR TITLE
Added default value and restriction per environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 If the the configuration `mongo-feature-toggles-client.useMongoTransactions = false` is used then the client won't use Mongo transactions. Do not override this in any environment. It is best suited while the service is started via service manager.
 
 ### Create a toggle
-Create a case object extending the FeatureFlagName trait
+Create a case object extending the FeatureFlagName trait.
+
+The lockedEnvironments allows to move the toggle per environment in a different part of the UI where their use is restricted.
 
 ```scala
 case object PertaxBackendToggle extends FeatureFlagName {
-  val name                                 = "pertax-backend-toggle"
-  override val description: Option[String] = Some(
-    "Enable/disable pertax backend during auth"
-  )
-}
+    override val description = Some("Description")
+    override val name = "toggle-name"
+    override val defaultState = false // State of the toggle when no entry is present in Mongo
+    override val lockedEnvironments = Seq(Environment.Production) // Locked toggled are placed in a different part of the UI
+  }
 ```
 
 ### Register toggles on application start

--- a/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/controllers/FeatureFlagsAdminController.scala
+++ b/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/controllers/FeatureFlagsAdminController.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.mongoFeatureToggles.controllers
 
 import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Results.Ok
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.mongoFeatureToggles.internal.actions.InternalAuthAction
 import uk.gov.hmrc.mongoFeatureToggles.model.{FeatureFlag, FeatureFlagName}
@@ -35,7 +36,9 @@ class FeatureFlagsAdminController @Inject() (
 
   def get: Action[AnyContent] = Action.async {
     featureFlagService.getAll
-      .map(flags => Ok(Json.toJson(flags)))
+      .map { flags =>
+        Ok(Json.toJson(flags))
+      }
   }
 
   def put(flagName: FeatureFlagName): Action[AnyContent] = auth().async { request =>

--- a/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/model/Environment.scala
+++ b/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/model/Environment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.mongoFeatureToggles.internal.model
+package uk.gov.hmrc.mongoFeatureToggles.model
 
 import play.api.libs.json.{Format, Json}
 
-private[mongoFeatureToggles] case class FeatureFlagSerialised(
-  name: String,
-  isEnabled: Boolean
-)
+object Environment extends Enumeration {
+  type Environment = Value
 
-private[mongoFeatureToggles] object FeatureFlagSerialised {
-  implicit val formats: Format[FeatureFlagSerialised] = Json.format[FeatureFlagSerialised]
+  val Local        = Value("Local")
+  val Dev          = Value("Dev")
+  val Staging      = Value("Staging")
+  val Qa           = Value("Qa")
+  val Production   = Value("Production")
+  val ExternalTest = Value("ExternalTest")
+
+  implicit val format: Format[Environment] = Json.formatEnum(this)
 }

--- a/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/model/FeatureFlag.scala
+++ b/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/model/FeatureFlag.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.mongoFeatureToggles.model
 
 import play.api.libs.json._
 
-case class FeatureFlag(name: FeatureFlagName, isEnabled: Boolean, description: Option[String] = None)
+case class FeatureFlag(name: FeatureFlagName, isEnabled: Boolean)
 
 object FeatureFlag {
   implicit final val format: OFormat[FeatureFlag] = Json.format[FeatureFlag]

--- a/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/services/FeatureFlagService.scala
+++ b/mongo-feature-toggles-client-play-30/src/main/scala/uk/gov/hmrc/mongoFeatureToggles/services/FeatureFlagService.scala
@@ -53,7 +53,7 @@ class FeatureFlagService @Inject() (
     cache.getOrElseUpdate(flagName.toString, cacheValidFor) {
       featureFlagRepository
         .getFeatureFlag(flagName)
-        .map(_.getOrElse(FeatureFlag(flagName, false)))
+        .map(_.getOrElse(FeatureFlag(flagName, flagName.defaultState)))
     }
 
   def get(flagName: FeatureFlagName): Future[FeatureFlag] = innerGet(flagName)
@@ -78,7 +78,7 @@ class FeatureFlagService @Inject() (
             if (featureFlags.map(_.name).contains(missingFlag)) {
               featureFlags
             } else {
-              FeatureFlag(missingFlag, false) :: featureFlags
+              FeatureFlag(missingFlag, missingFlag.defaultState) :: featureFlags
             }
           }
           .reverse

--- a/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositorySpec.scala
+++ b/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositorySpec.scala
@@ -67,11 +67,11 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
 
     "return a flag if there is a record" in {
       val result = (for {
-        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true, TestToggleA.description))
+        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true))
         result <- repository.getFeatureFlag(TestToggleA)
       } yield result).futureValue
 
-      result mustBe Some(FeatureFlag(TestToggleA, true, TestToggleA.description))
+      result mustBe Some(FeatureFlag(TestToggleA, true))
     }
   }
 
@@ -83,7 +83,7 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
       } yield result).futureValue
 
       result mustBe List(
-        FeatureFlagSerialised(TestToggleA.name, true, TestToggleA.description)
+        FeatureFlagSerialised(TestToggleA.name, true)
       )
     }
 
@@ -95,7 +95,7 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
       } yield result).futureValue
 
       result mustBe List(
-        FeatureFlagSerialised(TestToggleA.name, false, TestToggleA.description)
+        FeatureFlagSerialised(TestToggleA.name, false)
       )
     }
   }
@@ -111,7 +111,7 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
 
       result.sortBy(_.name) mustBe expectedFlags
         .map { case (key, value) =>
-          FeatureFlagSerialised(key.name, value, key.description)
+          FeatureFlagSerialised(key.name, value)
         }
         .toList
         .sortBy(_.name)
@@ -121,18 +121,18 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
   "getAllFeatureFlags" must {
     "get a list of all the feature toggles" in {
       val allFlags: Seq[FeatureFlag] = (for {
-        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true, TestToggleA.description))
+        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true))
         result <- repository.getAllFeatureFlags
       } yield result).futureValue
 
       allFlags mustBe List(
-        FeatureFlag(TestToggleA, true, TestToggleA.description)
+        FeatureFlag(TestToggleA, true)
       )
     }
 
     "get a deleted toggle" in {
       val allFlags: Seq[FeatureFlag] = (for {
-        _      <- insert(FeatureFlagSerialised("invalid", true, Some("invalid")))
+        _      <- insert(FeatureFlagSerialised("invalid", true))
         result <- repository.getAllFeatureFlags
       } yield result).futureValue
 
@@ -145,7 +145,7 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
   "deleteFeatureFlag" must {
     "delete a mongo record" in {
       val allFlags: Boolean = (for {
-        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true, TestToggleA.description))
+        _      <- insert(FeatureFlagSerialised(TestToggleA.name, true))
         result <- repository.deleteFeatureFlag(TestToggleA)
       } yield result).futureValue
 
@@ -158,8 +158,8 @@ class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepository
     "not allow duplicates" in {
       val result = intercept[MongoWriteException] {
         await(for {
-          _ <- insert(FeatureFlagSerialised(TestToggleA.name, true, TestToggleA.description))
-          _ <- insert(FeatureFlagSerialised(TestToggleA.name, false, TestToggleB.description))
+          _ <- insert(FeatureFlagSerialised(TestToggleA.name, true))
+          _ <- insert(FeatureFlagSerialised(TestToggleA.name, false))
         } yield true)
       }
       result.getCode mustBe 11000

--- a/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositoryWithoutTransactionsSpec.scala
+++ b/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/internal/repository/FeatureFlagRepositoryWithoutTransactionsSpec.scala
@@ -73,7 +73,7 @@ class FeatureFlagRepositoryWithoutTransactionsSpec
 
       result.sortBy(_.name) mustBe expectedFlags
         .map { case (key, value) =>
-          FeatureFlagSerialised(key.name, value, key.description)
+          FeatureFlagSerialised(key.name, value)
         }
         .toList
         .sortBy(_.name)

--- a/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/model/FeatureFlagNameSpec.scala
+++ b/mongo-feature-toggles-client-play-30/src/test/scala/uk/gov/hmrc/mongoFeatureToggles/model/FeatureFlagNameSpec.scala
@@ -39,8 +39,9 @@ class FeatureFlagNameSpec extends BaseSpec {
   }
 
   "write json" in {
-    Json.toJson(TestToggleA: FeatureFlagName).toString mustBe s""""${TestToggleA.name}""""
-    Json.toJson(TestToggleA: FeatureFlagName).toString mustBe s""""${TestToggleA.toString}""""
+    Json
+      .toJson(TestToggleA: FeatureFlagName)
+      .toString mustBe s"""{"name":"${TestToggleA.name}","description":"${TestToggleA.description.get}","defaultState":${TestToggleA.defaultState},"lockedEnvironments":[]}"""
   }
 
   "String binds to a Right(FeatureFlagName)" in {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ sys.env.get("PLAY_VERSION") match {
   case _           => addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 }
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"   % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"      % "2.2.1")


### PR DESCRIPTION
Added an option to have a default for the toggle when no entry is present in Mongo. i.e. when it's a new toggle.

Added an option to have the toggle labelled as `Restricted` per environment. This is purely aesthetic for now as this will not be enforced. At least for now. The admin frontend put those in a different section with some warning and explanation on using those.